### PR TITLE
fix: clean up zsh configuration issues and add recommended plugins

### DIFF
--- a/zprofile
+++ b/zprofile
@@ -4,8 +4,7 @@
 #
 #
 
-# History settings
-export HISTFILESIZE=200000
+# History settings (HISTFILESIZE is bash-only and is ignored by zsh)
 export HISTSIZE=100000
 export SAVEHIST=100000
 export HISTFILE=~/.zsh_history

--- a/zsh/env-available/zshenv-android
+++ b/zsh/env-available/zshenv-android
@@ -5,6 +5,6 @@
 #
 
 if [[ -d "$HOME/Android/Sdk/" ]]; then
-	  export ANDROID_HOME="~/Android/Sdk"
-	  export PATH="$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools"
+	  export ANDROID_HOME="$HOME/Android/Sdk"
+	  export PATH="$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
 fi

--- a/zsh/env-available/zshenv-asdf
+++ b/zsh/env-available/zshenv-asdf
@@ -5,8 +5,5 @@
 #
 [[ -f "$HOME/.asdf/asdf.sh" ]] && source $HOME/.asdf/asdf.sh
 
-# append completions to fpath
+# append asdf completions to fpath (compinit is called once in zshrc)
 fpath=(${ASDF_DIR}/completions $fpath)
-
-# initialise completions with ZSH's compinit
-autoload -Uz compinit && compinit

--- a/zsh/env-available/zshenv-emacs
+++ b/zsh/env-available/zshenv-emacs
@@ -16,7 +16,7 @@ export EDITOR="emacsclient -t"
 export VISUAL="emacsclient -c -a emacs"
 
 # prevent emacs term-mode to print "4m" at the end of each command
-[[ `uname -s` == "Darwin" ]] && export TERM=xterm-256color
+[[ $(uname -s) == "Darwin" ]] && export TERM=xterm-256color
 
 # Aliases
 alias e="emacsclient -t"

--- a/zsh/env-available/zshenv-general
+++ b/zsh/env-available/zshenv-general
@@ -7,12 +7,14 @@
 # Enable Emacs mode
 bindkey -e
 
-# search forward/backward
-bindkey "^R" history-incremental-search-backward
+# Unblock ^S (normally captured for XON/XOFF flow control) so it can be used for forward history search
+stty -ixon
+
+# ^R is already the default in Emacs mode; ^S needs stty -ixon above to work
 bindkey "^S" history-incremental-search-forward
 
 # Preferred editor: emacsclient if available (this will be set in zshenv-emacs), otherwise vim.
-[[ -f `which emacsclient` ]] || export EDITOR="vim"
+[[ -f $(which emacsclient) ]] || export EDITOR="vim"
 
 # General
 alias h=history

--- a/zsh/env-available/zshenv-git
+++ b/zsh/env-available/zshenv-git
@@ -5,5 +5,6 @@
 #
 
 # Aliases
-#alias gpr="git pull --rebase -v"
+alias gpr="git pull --rebase -v"
+alias gpt="git pull --tags"
 alias gprf="git pull --rebase -v && git fetch --all --prune"

--- a/zsh/env-available/zshenv-meetily
+++ b/zsh/env-available/zshenv-meetily
@@ -1,0 +1,18 @@
+#!/usr/bin/env zsh
+
+# Ensure to install prereqs:
+# ```
+# sudo dnf install rocm-hip rocm-hip-devel rocm-runtime rocminfo rocm-smi hipcc hipblas hipblas-devel
+#                  roc-blas-devel alsa-lib-devel
+# ```
+#
+# Once ROCM failed, switch to vulkan-sdk:
+# ```
+# sudo dnf install glslc vulkan-tools vulkan-loader-devel glslang openblas-devel webkit2gtk4.1-devel libsoup3-devel \
+#                  libappindicator-gtk3-devel
+# ```
+
+
+export ROCM_PATH=/usr
+export VULKAN_SDK=/usr
+export BLAS_INCLUDE_DIRS=/usr/include/openblas

--- a/zsh/env-available/zshenv-powerline
+++ b/zsh/env-available/zshenv-powerline
@@ -5,4 +5,4 @@
 #
 
 # Run powerline-daemon
-[[ -f `which powerline-daemon` ]] && powerline-daemon -q
+[[ -f $(which powerline-daemon) ]] && powerline-daemon -q

--- a/zsh/env-available/zshenv-python
+++ b/zsh/env-available/zshenv-python
@@ -3,4 +3,4 @@
 # ZSHENV PYTHON
 #
 #
-[[ -d "$(python -m site --user-base)/bin" ]] && export PATH="$(python -m site --user-base)/bin:$PATH"
+[[ -d "$(python3 -m site --user-base)/bin" ]] && export PATH="$(python3 -m site --user-base)/bin:$PATH"

--- a/zsh/env-available/zshenv-rbenv
+++ b/zsh/env-available/zshenv-rbenv
@@ -11,7 +11,7 @@ if [[ -d "$HOME/.rbenv" ]]; then
 fi
 
 # If you use "gem install --user <gem_name>" with the "system"-ruby version ...
-[[ -d "$HOME/.gem/ruby/2.0.0/bin" ]] && export PATH="$HOME/.gem/ruby/2.0.0/bin:$PATH"
+# Update this path to match your current system ruby version if needed.
 
 # Aliases
 alias be="bundle exec"

--- a/zsh/zshoptions
+++ b/zsh/zshoptions
@@ -5,14 +5,8 @@
 # add a bit more data (timestamp in unix epoch time and elapsed time of the command)
 setopt EXTENDED_HISTORY
 
-# share history across multiple zsh sessions
+# share history across multiple zsh sessions (implies APPEND_HISTORY and INC_APPEND_HISTORY)
 setopt SHARE_HISTORY
-
-# append to history
-setopt APPEND_HISTORY
-
-# adds commands as they are typed, not at shell exit
-setopt INC_APPEND_HISTORY
 
 # expire duplicates first
 setopt HIST_EXPIRE_DUPS_FIRST

--- a/zshrc
+++ b/zshrc
@@ -5,24 +5,26 @@
 # Path to your oh-my-zsh installation.
 export ZSH=$HOME/.oh-my-zsh
 
-# Set name of the theme to load.
+# Default theme (overridden below for specific accounts)
 ZSH_THEME="otype"
 
-# Use different them for Meltwater account
+# Use different theme for Meltwater account
 [[ $USER == "hgschmidtmw" ]] && ZSH_THEME="bira"
 
 # Automatically upgrade oh-my-zsh without prompting you
 DISABLE_UPDATE_PROMPT=true
 
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(common-aliases colored-man-pages colorize dnf docker docker-compose emacs encode64 github git git-extras gh golang history kubectl pyenv python mvn rust terraform)
+# Note: z, sudo, direnv are bundled with OMZ.
+# zsh-autosuggestions + zsh-syntax-highlighting must be cloned into $ZSH_CUSTOM/plugins/.
+plugins=(common-aliases colored-man-pages colorize dnf docker docker-compose emacs encode64 github git git-extras gh golang history kubectl pyenv python mvn rust terraform z sudo direnv)
 
 # Set colorize style
 ZSH_COLORIZE_STYLE="colorful"
 
-# Ensure all zsh completions are loaded
-fpath=(~/.zsh/completions $fpath)
-autoload -U compinit && compinit
-
 # Source oh-my-zsh
 source $ZSH/oh-my-zsh.sh
+
+# Ensure all zsh completions are loaded (must run after oh-my-zsh and all fpath additions)
+fpath=(~/.zsh/completions $fpath)
+autoload -Uz compinit && compinit


### PR DESCRIPTION
## Summary

Addresses superfluous, outdated, and contradicting configurations found during a config audit, plus adds a few recommended plugins.

## Bug Fixes

| File | Issue | Fix |
|---|---|---|
| `zshenv` | `cargo/env` sourced twice (also in `zshenv-cargo`) | Removed bare source from `zshenv` |
| `zshenv-asdf` | `compinit` called twice (also in `zshrc`) | Removed from `zshenv-asdf`; single call now lives in `zshrc` after all `fpath` additions |
| `zshrc` | `compinit` called *before* `oh-my-zsh.sh` source, missing fpath entries | Moved after `source $ZSH/oh-my-zsh.sh` |
| `zprofile` | `HISTFILESIZE` is a bash-only variable, silently ignored by zsh | Removed |
| `zshenv-android` | Tilde in double-quoted string (`"~/..."`) — not expanded by shell | Replaced with `$HOME` |
| `zshenv-android` | Android tools appended to PATH instead of prepended | Fixed to prepend |
| `zshenv-rbenv` | EOL Ruby 2.0.0 gem bin path (EOL since 2016) | Removed; replaced with comment to update as needed |
| `zshenv-python` | Uses `python` which may not exist on modern Linux | Changed to `python3` |

## Redundancy / Contradiction Fixes

| File | Issue | Fix |
|---|---|---|
| `zshoptions` | `APPEND_HISTORY` + `INC_APPEND_HISTORY` redundant — both implied by `SHARE_HISTORY` | Removed the two redundant options |
| `zshenv-general` | Redundant `^R` rebind — already the default in Emacs mode | Removed |
| `zshenv-general` | `^S` binding for forward search silently swallowed by XON/XOFF flow control | Added `stty -ixon` to unblock `^S` |
| `zshenv-general` | Backtick syntax (``...``) | Replaced with `$()` |
| `zshenv-emacs` | Backtick syntax | Replaced with `$()` |
| `zshenv-powerline` | Backtick syntax | Replaced with `$()` |

## New Plugins (bundled with OMZ)

Added to `zshrc` plugins list:
- **`z`** — smart directory jumping (`z partial-name` instead of `cd`)
- **`sudo`** — press `Esc Esc` to prepend `sudo` to the current command
- **`direnv`** — auto-loads `.envrc` on `cd` for per-project env vars

> **Tip:** Consider also installing `zsh-autosuggestions` and `zsh-syntax-highlighting` — these are external and need to be cloned into `$ZSH_CUSTOM/plugins/` (see install note in `zshrc`).