### PR TITLE
Move badges to top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Shell
-
-#### A ZSH setup via simple configurations.
-
 <p>
 	<a href="https://github.com/otype/shell/commits/master">
 	<img src="https://img.shields.io/github/last-commit/otype/shell.svg?style=flat-square&logo=github&logoColor=white" alt="GitHub last commit">
@@ -12,6 +8,10 @@
 	<a href="https://github.com/otype/shell/blob/main/LICENSE">
 	<img src="https://img.shields.io/github/license/otype/shell" alt="LICENSE">
 </p>
+
+# Shell
+
+#### A ZSH setup via simple configurations.
 
 Shell is a pluggable configuration for [ZSH](http://www.zsh.org/). Mainly focusing Linux-based systems (partially also Mac OS X), it provides helpful functions, aliases and PATH definitions for a variety of tools you might be using.
 


### PR DESCRIPTION
This pull request reorganizes the top section of the `README.md` file to improve clarity and structure. The main change is moving the project title and description below the project badges, making the introduction more prominent and easier to read.

Documentation improvements:

* Moved the `# Shell` heading and the short description to appear after the project badges, enhancing the visual hierarchy and readability of the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-L4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R15)