### PR TITLE
Guard stty call with TTY check to fix non-interactive session error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Shell
-
-#### A ZSH setup via simple configurations.
-
 <p>
 	<a href="https://github.com/otype/shell/commits/master">
 	<img src="https://img.shields.io/github/last-commit/otype/shell.svg?style=flat-square&logo=github&logoColor=white" alt="GitHub last commit">
@@ -12,6 +8,10 @@
 	<a href="https://github.com/otype/shell/blob/main/LICENSE">
 	<img src="https://img.shields.io/github/license/otype/shell" alt="LICENSE">
 </p>
+
+# Shell
+
+#### A ZSH setup via simple configurations.
 
 Shell is a pluggable configuration for [ZSH](http://www.zsh.org/). Mainly focusing Linux-based systems (partially also Mac OS X), it provides helpful functions, aliases and PATH definitions for a variety of tools you might be using.
 

--- a/zsh/env-available/zshenv-general
+++ b/zsh/env-available/zshenv-general
@@ -8,7 +8,7 @@
 bindkey -e
 
 # Unblock ^S (normally captured for XON/XOFF flow control) so it can be used for forward history search
-stty -ixon
+[[ -t 0 ]] && stty -ixon
 
 # ^R is already the default in Emacs mode; ^S needs stty -ixon above to work
 bindkey "^S" history-incremental-search-forward


### PR DESCRIPTION
## Problem

`stty -ixon` was running unconditionally in `zshenv-general`, causing:
```
stty: 'standard input': Inappropriate ioctl for device
```
in non-interactive sessions (scripts, SSH remote commands, etc.) that have no TTY attached.

## Fix

Guard the call with `[[ -t 0 ]]` so `stty` only runs when stdin is a real terminal. The `^S` forward-history search binding is unaffected in interactive sessions.